### PR TITLE
Use six.string_types to match Python 2 str

### DIFF
--- a/asgiref/base_layer.py
+++ b/asgiref/base_layer.py
@@ -83,7 +83,7 @@ class BaseChannelLayer(object):
         return self.capacity
 
     def match_type_and_length(self, name):
-        if (len(name) < 100) and (isinstance(name, six.text_type)):
+        if (len(name) < 100) and (isinstance(name, six.string_types)):
             return True
         return False
 


### PR DESCRIPTION
Why are we matching `six.text_type` and not `six.string_types`?
I ask because currently in Python 2 `ChannelTestCase` the following happens..

```
Channel("foo").send(...)   # works
self.get_next_message("foo")  
TypeError: Channel name must be a valid unicode string containing only alphanumerics, hyphens, or periods.
```

Related to: https://github.com/mongomock/mongomock/issues/239
